### PR TITLE
Bump GitHub Actions dependencies (consolidates dependabot #18, #20, #21, #23)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -23,6 +23,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -20,7 +20,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.5
+        uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -25,7 +25,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
## Summary

Consolidates the four open dependabot PRs into a single change set. One commit per dependency.

| Dependency | From | To | Source PR |
|------------|------|----|-----------|
| `aglipanci/laravel-pint-action` | 2.5 | 2.6 | #18 |
| `dependabot/fetch-metadata` | v2.4.0 | v2.5.0 | #23 |
| `actions/checkout` | v4 | v6 | #21 |
| `stefanzweifel/git-auto-commit-action` | v5 | v7 | #20 |

## Compatibility notes

- **`actions/checkout` v4 → v6** (major×2): v5 moved to Node 24; v6 persists git creds to `$RUNNER_TEMP` instead of the local git config and requires runner ≥ v2.329.0. We use GitHub-hosted `ubuntu-latest`/`windows-latest` (well above that minimum) and no Docker container actions, so no impact.
- **`git-auto-commit-action` v5 → v7** (major×2): v6.0.0 removed `create_branch` / `skip_checkout` / `skip_fetch` and added a detached-HEAD check; v7.0.0 restored those inputs. Our workflows only pass `commit_message`, `branch`, and `file_pattern`, and check out branch refs (not SHAs), so no impact.
- **`laravel-pint-action` 2.5 → 2.6**: adds optional parallel mode; backward-compatible.
- **`fetch-metadata` v2.4.0 → v2.5.0**: internal dep bumps only; same `update-type` output used by the auto-merge workflow.

## Test plan

- [ ] CI green on this PR (run-tests workflow uses the new `actions/checkout@v6`)
- [ ] After merge, verify the next PR push triggers `fix-php-code-style-issues.yml` correctly (uses new `actions/checkout@v6`, `laravel-pint-action@2.6`, and `git-auto-commit-action@v7`)
- [ ] Confirm dependabot auto-closes #18, #20, #21, #23 once the bumps land on `main` (otherwise close manually)